### PR TITLE
Mikebranch2

### DIFF
--- a/utils/Pintos.pm
+++ b/utils/Pintos.pm
@@ -359,7 +359,7 @@ sub cyl_sectors {
 # Makes sure that the loader is a reasonable size.
 sub read_loader {
     my ($name) = @_;
-    $name = find_file ("/home/mikec/git-repos/pintos-anon/src/threads/build/loader.bin") if !defined $name;
+    $name = find_file ("/home/andy/git-repos/pintos-anon/src/threads/build/loader.bin") if !defined $name;
     die "Cannot find loader\n" if !defined $name;
 
     my ($handle);


### PR DESCRIPTION
fixed semaphores not prempting or sorting waiter list according to priority. priority-donate-one is almost passing now. the locks get passed around in the right order but the initial creation msg's display wrong priority. This should be resolved when donation is implemented as the base thread should get the priority of the newly created threads.
