### PR TITLE
Mikebranch2

### DIFF
--- a/utils/Pintos.pm
+++ b/utils/Pintos.pm
@@ -359,7 +359,7 @@ sub cyl_sectors {
 # Makes sure that the loader is a reasonable size.
 sub read_loader {
     my ($name) = @_;
-    $name = find_file ("/home/mikec/git-repos/pintos-anon/src/threads/build/loader.bin") if !defined $name;
+    $name = find_file ("/home/andy/git-repos/pintos-anon/src/threads/build/loader.bin") if !defined $name;
     die "Cannot find loader\n" if !defined $name;
 
     my ($handle);

--- a/utils/pintos
+++ b/utils/pintos
@@ -254,7 +254,7 @@ sub set_disk {
 sub find_disks {
     # Find kernel, if we don't already have one.
     if (!exists $parts{KERNEL}) {
-	my $name = find_file ('/home/mikec/git-repos/pintos-anon/src/threads/build/kernel.bin');
+	my $name = find_file ('/home/andy/git-repos/pintos-anon/src/threads/build/kernel.bin');
 	die "Cannot find kernel\n" if !defined $name;
 	do_set_part ('KERNEL', 'file', $name);
     }

--- a/utils/pintos-gdb
+++ b/utils/pintos-gdb
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 # Path to GDB macros file.  Customize for your site.
-GDBMACROS=/home/mikec/git-repos/pintos-anon/src/misc/gdb-macros
+GDBMACROS=/home/andy/git-repos/pintos-anon/src/misc/gdb-macros
 
 # Choose correct GDB.
 if command -v i386-elf-gdb >/dev/null 2>&1; then


### PR DESCRIPTION
fixed semaphores not prempting or sorting waiter list according to priority. priority-donate-one is almost passing now. the locks get passed around in the right order but the initial creation msg's display wrong priority. This should be resolved when donation is implemented as the base thread should get the priority of the newly created threads. also added a .gitignore to ignore directory setup files from pintos. not 100% sure if i did this right but i think it should work.
